### PR TITLE
[WIP] tests refactor: separate connector-specific tests

### DIFF
--- a/presto-accumulo/src/test/java/com/facebook/presto/accumulo/TestAccumuloDistributedQueries.java
+++ b/presto-accumulo/src/test/java/com/facebook/presto/accumulo/TestAccumuloDistributedQueries.java
@@ -55,41 +55,6 @@ public class TestAccumuloDistributedQueries
     }
 
     @Override
-    public void testCreateTableAsSelect()
-    {
-        // This test is overridden due to Function "UUID" not found errors
-        // Some test cases from the base class are removed
-
-        assertUpdate("CREATE TABLE test_create_table_as_if_not_exists (a bigint, b double)");
-        assertTrue(getQueryRunner().tableExists(getSession(), "test_create_table_as_if_not_exists"));
-        assertTableColumnNames("test_create_table_as_if_not_exists", "a", "b");
-
-        assertUpdate("CREATE TABLE IF NOT EXISTS test_create_table_as_if_not_exists AS SELECT UUID() AS uuid, orderkey, discount FROM lineitem", 0);
-        assertTrue(getQueryRunner().tableExists(getSession(), "test_create_table_as_if_not_exists"));
-        assertTableColumnNames("test_create_table_as_if_not_exists", "a", "b");
-
-        assertUpdate("DROP TABLE test_create_table_as_if_not_exists");
-        assertFalse(getQueryRunner().tableExists(getSession(), "test_create_table_as_if_not_exists"));
-
-        this.assertCreateTableAsSelect(
-                "test_group",
-                "SELECT orderstatus, sum(totalprice) x FROM orders GROUP BY orderstatus",
-                "SELECT count(DISTINCT orderstatus) FROM orders");
-
-        this.assertCreateTableAsSelect(
-                "test_with_data",
-                "SELECT * FROM orders WITH DATA",
-                "SELECT * FROM orders",
-                "SELECT count(*) FROM orders");
-
-        this.assertCreateTableAsSelect(
-                "test_with_no_data",
-                "SELECT * FROM orders WITH NO DATA",
-                "SELECT * FROM orders LIMIT 0",
-                "SELECT 0");
-    }
-
-    @Override
     public void testDelete()
     {
         // Deletes are not supported by the connector

--- a/presto-accumulo/src/test/java/com/facebook/presto/accumulo/TestAccumuloIntegrationSmokeTest.java
+++ b/presto-accumulo/src/test/java/com/facebook/presto/accumulo/TestAccumuloIntegrationSmokeTest.java
@@ -87,4 +87,10 @@ public class TestAccumuloIntegrationSmokeTest
                 "SELECT * FROM orders LIMIT 0",
                 "SELECT 0");
     }
+
+    @Override
+    public void testDelete()
+    {
+        // this connector does not support DELETE
+    }
 }

--- a/presto-cassandra/src/test/java/com/facebook/presto/cassandra/TestCassandraDistributed.java
+++ b/presto-cassandra/src/test/java/com/facebook/presto/cassandra/TestCassandraDistributed.java
@@ -87,12 +87,6 @@ public class TestCassandraDistributed
     }
 
     @Override
-    public void testCreateTable()
-    {
-        // Cassandra connector currently does not support create table
-    }
-
-    @Override
     public void testCreateTableAsSelect()
     {
         // Cassandra connector currently does not support create table

--- a/presto-cassandra/src/test/java/com/facebook/presto/cassandra/TestCassandraIntegrationSmokeTest.java
+++ b/presto-cassandra/src/test/java/com/facebook/presto/cassandra/TestCassandraIntegrationSmokeTest.java
@@ -84,6 +84,18 @@ public class TestCassandraIntegrationSmokeTest
         createTestTables(session, KEYSPACE, DATE_LOCAL);
     }
 
+    @Override
+    protected boolean isDateTypeSupported()
+    {
+        return false;
+    }
+
+    @Override
+    protected boolean isParameterizedVarcharSupported()
+    {
+        return false;
+    }
+
     @Test
     public void testPartitionKeyPredicate()
     {

--- a/presto-cassandra/src/test/java/com/facebook/presto/cassandra/TestCassandraIntegrationSmokeTest.java
+++ b/presto-cassandra/src/test/java/com/facebook/presto/cassandra/TestCassandraIntegrationSmokeTest.java
@@ -102,6 +102,12 @@ public class TestCassandraIntegrationSmokeTest
         // this connector does not support creating tables (only CREATE TABLE AS SELECT is supported)
     }
 
+    @Override
+    public void testDelete()
+    {
+        // this connector does not support DELETE
+    }
+
     @Test
     public void testPartitionKeyPredicate()
     {

--- a/presto-cassandra/src/test/java/com/facebook/presto/cassandra/TestCassandraIntegrationSmokeTest.java
+++ b/presto-cassandra/src/test/java/com/facebook/presto/cassandra/TestCassandraIntegrationSmokeTest.java
@@ -96,6 +96,12 @@ public class TestCassandraIntegrationSmokeTest
         return false;
     }
 
+    @Override
+    public void testCreateTable()
+    {
+        // this connector does not support creating tables (only CREATE TABLE AS SELECT is supported)
+    }
+
     @Test
     public void testPartitionKeyPredicate()
     {

--- a/presto-kafka/src/test/java/com/facebook/presto/kafka/TestKafkaIntegrationSmokeTest.java
+++ b/presto-kafka/src/test/java/com/facebook/presto/kafka/TestKafkaIntegrationSmokeTest.java
@@ -66,4 +66,10 @@ public class TestKafkaIntegrationSmokeTest
     {
         // this connector does not support creating tables
     }
+
+    @Override
+    public void testDelete()
+    {
+        //  this connector does not support creating tables and this is required by testDelete
+    }
 }

--- a/presto-kafka/src/test/java/com/facebook/presto/kafka/TestKafkaIntegrationSmokeTest.java
+++ b/presto-kafka/src/test/java/com/facebook/presto/kafka/TestKafkaIntegrationSmokeTest.java
@@ -48,4 +48,22 @@ public class TestKafkaIntegrationSmokeTest
     {
         embeddedKafka.close();
     }
+
+    @Override
+    public void testCreateTable()
+    {
+        // this connector does not support creating tables
+    }
+
+    @Override
+    public void testCreateTableAsSelect()
+    {
+        // this connector does not support creating tables
+    }
+
+    @Override
+    public void createTableWithUnicode()
+    {
+        // this connector does not support creating tables
+    }
 }

--- a/presto-mongodb/src/test/java/com/facebook/presto/mongodb/TestMongoIntegrationSmokeTest.java
+++ b/presto-mongodb/src/test/java/com/facebook/presto/mongodb/TestMongoIntegrationSmokeTest.java
@@ -58,6 +58,18 @@ public class TestMongoIntegrationSmokeTest
         mongoQueryRunner = null;
     }
 
+    @Override
+    public void testCreateTable()
+    {
+        // TODO: test fails because table is visible after is has been dropped
+    }
+
+    @Override
+    public void testCreateTableAsSelect()
+    {
+        // TODO: test fails because table is visible after is has been dropped
+    }
+
     @Test
     public void createTableWithEveryType()
     {

--- a/presto-mongodb/src/test/java/com/facebook/presto/mongodb/TestMongoIntegrationSmokeTest.java
+++ b/presto-mongodb/src/test/java/com/facebook/presto/mongodb/TestMongoIntegrationSmokeTest.java
@@ -102,6 +102,12 @@ public class TestMongoIntegrationSmokeTest
         assertFalse(getQueryRunner().tableExists(getSession(), "test_types_table"));
     }
 
+    @Override
+    public void testDelete()
+    {
+        // this connector does not support DELETE
+    }
+
     @Test
     public void testInsertWithEveryType()
             throws Exception

--- a/presto-mysql/src/test/java/com/facebook/presto/plugin/mysql/TestMySqlIntegrationSmokeTest.java
+++ b/presto-mysql/src/test/java/com/facebook/presto/plugin/mysql/TestMySqlIntegrationSmokeTest.java
@@ -65,7 +65,6 @@ public class TestMySqlIntegrationSmokeTest
         // we need specific implementation of this tests due to specific Presto<->Mysql varchar length mapping.
         MaterializedResult actualColumns = computeActual("DESC ORDERS").toTestTypes();
 
-        // some connectors don't support dates, and some do not support parametrized varchars, so we check multiple options
         MaterializedResult expectedColumns = MaterializedResult.resultBuilder(getQueryRunner().getDefaultSession(), VARCHAR, VARCHAR, VARCHAR, VARCHAR)
                 .row("orderkey", "bigint", "", "")
                 .row("custkey", "bigint", "", "")

--- a/presto-mysql/src/test/java/com/facebook/presto/plugin/mysql/TestMySqlIntegrationSmokeTest.java
+++ b/presto-mysql/src/test/java/com/facebook/presto/plugin/mysql/TestMySqlIntegrationSmokeTest.java
@@ -92,16 +92,6 @@ public class TestMySqlIntegrationSmokeTest
     }
 
     @Test
-    public void testDropTable()
-    {
-        assertUpdate("CREATE TABLE test_drop AS SELECT 123 x", 1);
-        assertTrue(getQueryRunner().tableExists(getSession(), "test_drop"));
-
-        assertUpdate("DROP TABLE test_drop");
-        assertFalse(getQueryRunner().tableExists(getSession(), "test_drop"));
-    }
-
-    @Test
     public void testViews()
             throws SQLException
     {

--- a/presto-mysql/src/test/java/com/facebook/presto/plugin/mysql/TestMySqlIntegrationSmokeTest.java
+++ b/presto-mysql/src/test/java/com/facebook/presto/plugin/mysql/TestMySqlIntegrationSmokeTest.java
@@ -79,6 +79,18 @@ public class TestMySqlIntegrationSmokeTest
         assertEquals(actualColumns, expectedColumns);
     }
 
+    @Override
+    public void testCreateTable()
+    {
+        // this connector does not support creating tables (only CREATE TABLE AS SELECT is supported)
+    }
+
+    @Override
+    public void createTableWithUnicode()
+    {
+        // TODO fix or document the limitation
+    }
+
     @Test
     public void testDropTable()
     {

--- a/presto-postgresql/src/test/java/com/facebook/presto/plugin/postgresql/TestPostgreSqlDistributedQueries.java
+++ b/presto-postgresql/src/test/java/com/facebook/presto/plugin/postgresql/TestPostgreSqlDistributedQueries.java
@@ -56,5 +56,5 @@ public class TestPostgreSqlDistributedQueries
         // https://github.com/prestodb/presto/issues/5752
     }
 
-    // PostgreSQL specific tests should normally go in TestPostgreSqlDistributedQueries
+    // PostgreSQL specific tests should normally go in TestPostgreSqlIntegrationSmokeTest
 }

--- a/presto-postgresql/src/test/java/com/facebook/presto/plugin/postgresql/TestPostgreSqlIntegrationSmokeTest.java
+++ b/presto-postgresql/src/test/java/com/facebook/presto/plugin/postgresql/TestPostgreSqlIntegrationSmokeTest.java
@@ -27,7 +27,6 @@ import java.sql.Statement;
 import static io.airlift.tpch.TpchTable.ORDERS;
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
 @Test
@@ -61,16 +60,6 @@ public class TestPostgreSqlIntegrationSmokeTest
     public void testCreateTable()
     {
         // this connector does not support creating tables (only CREATE TABLE AS SELECT is supported)
-    }
-
-    @Test
-    public void testDropTable()
-    {
-        assertUpdate("CREATE TABLE test_drop AS SELECT 123 x", 1);
-        assertTrue(getQueryRunner().tableExists(getSession(), "test_drop"));
-
-        assertUpdate("DROP TABLE test_drop");
-        assertFalse(getQueryRunner().tableExists(getSession(), "test_drop"));
     }
 
     @Test

--- a/presto-postgresql/src/test/java/com/facebook/presto/plugin/postgresql/TestPostgreSqlIntegrationSmokeTest.java
+++ b/presto-postgresql/src/test/java/com/facebook/presto/plugin/postgresql/TestPostgreSqlIntegrationSmokeTest.java
@@ -57,6 +57,12 @@ public class TestPostgreSqlIntegrationSmokeTest
         postgreSqlServer.close();
     }
 
+    @Override
+    public void testCreateTable()
+    {
+        // this connector does not support creating tables (only CREATE TABLE AS SELECT is supported)
+    }
+
     @Test
     public void testDropTable()
     {

--- a/presto-redis/src/test/java/com/facebook/presto/redis/TestRedisIntegrationSmokeTest.java
+++ b/presto-redis/src/test/java/com/facebook/presto/redis/TestRedisIntegrationSmokeTest.java
@@ -45,4 +45,22 @@ public class TestRedisIntegrationSmokeTest
     {
         embeddedRedis.close();
     }
+
+    @Override
+    public void testCreateTable()
+    {
+        // this connector does not support creating tables
+    }
+
+    @Override
+    public void testCreateTableAsSelect()
+    {
+        // this connector does not support creating tables
+    }
+
+    @Override
+    public void createTableWithUnicode()
+    {
+        // this connector does not support creating tables
+    }
 }

--- a/presto-redis/src/test/java/com/facebook/presto/redis/TestRedisIntegrationSmokeTest.java
+++ b/presto-redis/src/test/java/com/facebook/presto/redis/TestRedisIntegrationSmokeTest.java
@@ -63,4 +63,10 @@ public class TestRedisIntegrationSmokeTest
     {
         // this connector does not support creating tables
     }
+
+    @Override
+    public void testDelete()
+    {
+        // this connector does not support creating tables and this is required by testDelete
+    }
 }

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestDistributedQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestDistributedQueries.java
@@ -395,54 +395,7 @@ public abstract class AbstractTestDistributedQueries
     @Test
     public void testDelete()
     {
-        // delete half the table, then delete the rest
-
-        assertUpdate("CREATE TABLE test_delete AS SELECT * FROM orders", "SELECT count(*) FROM orders");
-
-        assertUpdate("DELETE FROM test_delete WHERE orderkey % 2 = 0", "SELECT count(*) FROM orders WHERE orderkey % 2 = 0");
-        assertQuery("SELECT * FROM test_delete", "SELECT * FROM orders WHERE orderkey % 2 <> 0");
-
-        assertUpdate("DELETE FROM test_delete", "SELECT count(*) FROM orders WHERE orderkey % 2 <> 0");
-        assertQuery("SELECT * FROM test_delete", "SELECT * FROM orders LIMIT 0");
-
-        assertUpdate("DROP TABLE test_delete");
-
-        // delete successive parts of the table
-
-        assertUpdate("CREATE TABLE test_delete AS SELECT * FROM orders", "SELECT count(*) FROM orders");
-
-        assertUpdate("DELETE FROM test_delete WHERE custkey <= 100", "SELECT count(*) FROM orders WHERE custkey <= 100");
-        assertQuery("SELECT * FROM test_delete", "SELECT * FROM orders WHERE custkey > 100");
-
-        assertUpdate("DELETE FROM test_delete WHERE custkey <= 300", "SELECT count(*) FROM orders WHERE custkey > 100 AND custkey <= 300");
-        assertQuery("SELECT * FROM test_delete", "SELECT * FROM orders WHERE custkey > 300");
-
-        assertUpdate("DELETE FROM test_delete WHERE custkey <= 500", "SELECT count(*) FROM orders WHERE custkey > 300 AND custkey <= 500");
-        assertQuery("SELECT * FROM test_delete", "SELECT * FROM orders WHERE custkey > 500");
-
-        assertUpdate("DROP TABLE test_delete");
-
-        // delete using a constant property
-
-        assertUpdate("CREATE TABLE test_delete AS SELECT * FROM orders", "SELECT count(*) FROM orders");
-
-        assertUpdate("DELETE FROM test_delete WHERE orderstatus = 'O'", "SELECT count(*) FROM orders WHERE orderstatus = 'O'");
-        assertQuery("SELECT * FROM test_delete", "SELECT * FROM orders WHERE orderstatus <> 'O'");
-
-        assertUpdate("DROP TABLE test_delete");
-
-        // delete without matching any rows
-
-        assertUpdate("CREATE TABLE test_delete AS SELECT * FROM orders", "SELECT count(*) FROM orders");
-        assertUpdate("DELETE FROM test_delete WHERE rand() < 0", 0);
-        assertUpdate("DELETE FROM test_delete WHERE orderkey < 0", 0);
-        assertUpdate("DROP TABLE test_delete");
-
-        // delete with a predicate that optimizes to false
-
-        assertUpdate("CREATE TABLE test_delete AS SELECT * FROM orders", "SELECT count(*) FROM orders");
-        assertUpdate("DELETE FROM test_delete WHERE orderkey > 5 AND orderkey < 4", 0);
-        assertUpdate("DROP TABLE test_delete");
+        // Simple test cases, covering DELETE support in a connector, go to AbstractTestIntegrationSmokeTest
 
         // delete using a subquery
 

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestIntegrationSmokeTest.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestIntegrationSmokeTest.java
@@ -224,6 +224,7 @@ public abstract class AbstractTestIntegrationSmokeTest
         }
     }
 
+    // This also tests DROP TABLE
     @Test
     public void testCreateTable()
     {
@@ -261,6 +262,7 @@ public abstract class AbstractTestIntegrationSmokeTest
         assertFalse(getQueryRunner().tableExists(getSession(), "test_create_like"));
     }
 
+    // This also tests DROP TABLE
     @Test
     public void testCreateTableAsSelect()
     {

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestIntegrationSmokeTest.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestIntegrationSmokeTest.java
@@ -332,4 +332,57 @@ public abstract class AbstractTestIntegrationSmokeTest
         assertUpdate("DROP TABLE IF EXISTS test_drop_if_exists");
         assertFalse(getQueryRunner().tableExists(getSession(), "test_drop_if_exists"));
     }
+
+    @Test
+    public void testDelete()
+    {
+        // delete half the table, then delete the rest
+
+        assertUpdate("CREATE TABLE test_delete AS SELECT * FROM orders", "SELECT count(*) FROM orders");
+
+        assertUpdate("DELETE FROM test_delete WHERE orderkey % 2 = 0", "SELECT count(*) FROM orders WHERE orderkey % 2 = 0");
+        assertQuery("SELECT * FROM test_delete", "SELECT * FROM orders WHERE orderkey % 2 <> 0");
+
+        assertUpdate("DELETE FROM test_delete", "SELECT count(*) FROM orders WHERE orderkey % 2 <> 0");
+        assertQuery("SELECT * FROM test_delete", "SELECT * FROM orders LIMIT 0");
+
+        assertUpdate("DROP TABLE test_delete");
+
+        // delete successive parts of the table
+
+        assertUpdate("CREATE TABLE test_delete AS SELECT * FROM orders", "SELECT count(*) FROM orders");
+
+        assertUpdate("DELETE FROM test_delete WHERE custkey <= 100", "SELECT count(*) FROM orders WHERE custkey <= 100");
+        assertQuery("SELECT * FROM test_delete", "SELECT * FROM orders WHERE custkey > 100");
+
+        assertUpdate("DELETE FROM test_delete WHERE custkey <= 300", "SELECT count(*) FROM orders WHERE custkey > 100 AND custkey <= 300");
+        assertQuery("SELECT * FROM test_delete", "SELECT * FROM orders WHERE custkey > 300");
+
+        assertUpdate("DELETE FROM test_delete WHERE custkey <= 500", "SELECT count(*) FROM orders WHERE custkey > 300 AND custkey <= 500");
+        assertQuery("SELECT * FROM test_delete", "SELECT * FROM orders WHERE custkey > 500");
+
+        assertUpdate("DROP TABLE test_delete");
+
+        // delete using a constant property
+
+        assertUpdate("CREATE TABLE test_delete AS SELECT * FROM orders", "SELECT count(*) FROM orders");
+
+        assertUpdate("DELETE FROM test_delete WHERE orderstatus = 'O'", "SELECT count(*) FROM orders WHERE orderstatus = 'O'");
+        assertQuery("SELECT * FROM test_delete", "SELECT * FROM orders WHERE orderstatus <> 'O'");
+
+        assertUpdate("DROP TABLE test_delete");
+
+        // delete without matching any rows
+
+        assertUpdate("CREATE TABLE test_delete AS SELECT * FROM orders", "SELECT count(*) FROM orders");
+        assertUpdate("DELETE FROM test_delete WHERE rand() < 0", 0);
+        assertUpdate("DELETE FROM test_delete WHERE orderkey < 0", 0);
+        assertUpdate("DROP TABLE test_delete");
+
+        // delete with a predicate that optimizes to false
+
+        assertUpdate("CREATE TABLE test_delete AS SELECT * FROM orders", "SELECT count(*) FROM orders");
+        assertUpdate("DELETE FROM test_delete WHERE orderkey > 5 AND orderkey < 4", 0);
+        assertUpdate("DROP TABLE test_delete");
+    }
 }

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestIntegrationSmokeTest.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestIntegrationSmokeTest.java
@@ -197,19 +197,6 @@ public abstract class AbstractTestIntegrationSmokeTest
             return MaterializedResult.resultBuilder(getQueryRunner().getDefaultSession(), VARCHAR, VARCHAR, VARCHAR, VARCHAR)
                     .row("orderkey", "bigint", "", "")
                     .row("custkey", "bigint", "", "")
-                    .row("orderstatus", "varchar", "", "")
-                    .row("totalprice", "double", "", "")
-                    .row("orderdate", orderDateType, "", "")
-                    .row("orderpriority", "varchar", "", "")
-                    .row("clerk", "varchar", "", "")
-                    .row("shippriority", "integer", "", "")
-                    .row("comment", "varchar", "", "")
-                    .build();
-        }
-        else {
-            return MaterializedResult.resultBuilder(getQueryRunner().getDefaultSession(), VARCHAR, VARCHAR, VARCHAR, VARCHAR)
-                    .row("orderkey", "bigint", "", "")
-                    .row("custkey", "bigint", "", "")
                     .row("orderstatus", "varchar(1)", "", "")
                     .row("totalprice", "double", "", "")
                     .row("orderdate", orderDateType, "", "")
@@ -217,6 +204,19 @@ public abstract class AbstractTestIntegrationSmokeTest
                     .row("clerk", "varchar(15)", "", "")
                     .row("shippriority", "integer", "", "")
                     .row("comment", "varchar(79)", "", "")
+                    .build();
+        }
+        else {
+            return MaterializedResult.resultBuilder(getQueryRunner().getDefaultSession(), VARCHAR, VARCHAR, VARCHAR, VARCHAR)
+                    .row("orderkey", "bigint", "", "")
+                    .row("custkey", "bigint", "", "")
+                    .row("orderstatus", "varchar", "", "")
+                    .row("totalprice", "double", "", "")
+                    .row("orderdate", orderDateType, "", "")
+                    .row("orderpriority", "varchar", "", "")
+                    .row("clerk", "varchar", "", "")
+                    .row("shippriority", "integer", "", "")
+                    .row("comment", "varchar", "", "")
                     .build();
         }
     }

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestIntegrationSmokeTest.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestIntegrationSmokeTest.java
@@ -116,10 +116,10 @@ public abstract class AbstractTestIntegrationSmokeTest
 
         // some connectors don't support dates, and some do not support parametrized varchars, so we check multiple options
         List<MaterializedResult> expectedColumnsPossibilities = ImmutableList.of(
-                getExpectedTableDescription(true, true),
-                getExpectedTableDescription(true, false),
-                getExpectedTableDescription(false, true),
-                getExpectedTableDescription(false, false));
+                getExpectedOrdersTableDescription(true, true),
+                getExpectedOrdersTableDescription(true, false),
+                getExpectedOrdersTableDescription(false, true),
+                getExpectedOrdersTableDescription(false, false));
         assertTrue(expectedColumnsPossibilities.contains(actualColumns), String.format("%s not in %s", actualColumns, expectedColumnsPossibilities));
     }
 
@@ -184,7 +184,7 @@ public abstract class AbstractTestIntegrationSmokeTest
                 "line 1:49: Column name 'orderkey' specified more than once");
     }
 
-    private MaterializedResult getExpectedTableDescription(boolean dateSupported, boolean parametrizedVarchar)
+    private MaterializedResult getExpectedOrdersTableDescription(boolean dateSupported, boolean parametrizedVarchar)
     {
         String orderDateType;
         if (dateSupported) {

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestIntegrationSmokeTest.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestIntegrationSmokeTest.java
@@ -14,15 +14,12 @@
 package com.facebook.presto.tests;
 
 import com.facebook.presto.testing.MaterializedResult;
-import com.google.common.collect.ImmutableList;
 import org.intellij.lang.annotations.Language;
 import org.testng.annotations.Test;
 
-import java.util.List;
-
 import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
 import static com.facebook.presto.tests.QueryAssertions.assertContains;
-import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.assertEquals;
 
 public abstract class AbstractTestIntegrationSmokeTest
         extends AbstractTestQueryFramework
@@ -30,6 +27,16 @@ public abstract class AbstractTestIntegrationSmokeTest
     protected AbstractTestIntegrationSmokeTest(QueryRunnerSupplier supplier)
     {
         super(supplier);
+    }
+
+    protected boolean isDateTypeSupported()
+    {
+        return true;
+    }
+
+    protected boolean isParameterizedVarcharSupported()
+    {
+        return true;
     }
 
     @Test
@@ -113,14 +120,7 @@ public abstract class AbstractTestIntegrationSmokeTest
     public void testDescribeTable()
     {
         MaterializedResult actualColumns = computeActual("DESC ORDERS").toTestTypes();
-
-        // some connectors don't support dates, and some do not support parametrized varchars, so we check multiple options
-        List<MaterializedResult> expectedColumnsPossibilities = ImmutableList.of(
-                getExpectedOrdersTableDescription(true, true),
-                getExpectedOrdersTableDescription(true, false),
-                getExpectedOrdersTableDescription(false, true),
-                getExpectedOrdersTableDescription(false, false));
-        assertTrue(expectedColumnsPossibilities.contains(actualColumns), String.format("%s not in %s", actualColumns, expectedColumnsPossibilities));
+        assertEquals(actualColumns, getExpectedOrdersTableDescription(isDateTypeSupported(), isParameterizedVarcharSupported()));
     }
 
     @Test

--- a/presto-thrift-connector/src/test/java/com/facebook/presto/connector/thrift/integration/TestThriftIntegrationSmokeTest.java
+++ b/presto-thrift-connector/src/test/java/com/facebook/presto/connector/thrift/integration/TestThriftIntegrationSmokeTest.java
@@ -39,4 +39,22 @@ public class TestThriftIntegrationSmokeTest
                 .row("sf1");
         assertContains(actualSchemas, resultBuilder.build());
     }
+
+    @Override
+    public void testCreateTable()
+    {
+        // this connector does not support creating tables
+    }
+
+    @Override
+    public void testCreateTableAsSelect()
+    {
+        // this connector does not support creating tables
+    }
+
+    @Override
+    public void createTableWithUnicode()
+    {
+        // this connector does not support creating tables
+    }
 }

--- a/presto-thrift-connector/src/test/java/com/facebook/presto/connector/thrift/integration/TestThriftIntegrationSmokeTest.java
+++ b/presto-thrift-connector/src/test/java/com/facebook/presto/connector/thrift/integration/TestThriftIntegrationSmokeTest.java
@@ -57,4 +57,10 @@ public class TestThriftIntegrationSmokeTest
     {
         // this connector does not support creating tables
     }
+
+    @Override
+    public void testDelete()
+    {
+        //  this connector does not support creating tables and this is required by testDelete
+    }
 }


### PR DESCRIPTION
This implements a partial cleanup of connector-specific and connector-independent tests.
It's targeted at `starburstdata/presto`, since there is no intention to merge this, just to gather feedback.

What this does:
1. moves selected connector-specific tests to `AbstractTestIntegrationSmokeTest` (this seems to be _the class_ dedicated to connector-specific tests, despite the name)

What this does not:
1. This does not introduce any mechanism for bulk disabling of tests. Still, if a specific class is not expected to run a test (e.g. `testCreateTable` because e.g. table creation is not supported), the test method needs to be overridden.

What is still to be done:
1. Move other connector-specific tests from `AbstractTestDistributedQueries` in the same manner (rename table; add column; drop column; insert; view-related; testWrittenStats?)
2. remove connector-specific subclasses of `AbstractTestDistributedQueries`
