### PR TITLE
Cache stats for equivalent joins for ReorderJoins

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/cost/CachingStatsProvider.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/CachingStatsProvider.java
@@ -13,56 +13,43 @@
  */
 package com.facebook.presto.cost;
 
-import com.facebook.presto.Session;
-import com.facebook.presto.spi.type.Type;
-import com.facebook.presto.sql.planner.Symbol;
 import com.facebook.presto.sql.planner.iterative.GroupReference;
-import com.facebook.presto.sql.planner.iterative.Lookup;
 import com.facebook.presto.sql.planner.iterative.Memo;
 import com.facebook.presto.sql.planner.plan.PlanNode;
-import com.google.common.base.Suppliers;
 
 import java.util.IdentityHashMap;
 import java.util.Map;
 import java.util.Optional;
-import java.util.function.Supplier;
 
-import static com.facebook.presto.sql.planner.iterative.Lookup.noLookup;
 import static com.google.common.base.Verify.verify;
 import static java.util.Objects.requireNonNull;
 
 public final class CachingStatsProvider
-        implements StatsProvider
+        extends StatsProvider
 {
-    private final StatsCalculator statsCalculator;
+    private final StatsProvider delegate;
     private final Optional<Memo> memo;
-    private final Lookup lookup;
-    private final Session session;
-    private final Supplier<Map<Symbol, Type>> types;
 
     private final Map<PlanNode, PlanNodeStatsEstimate> cache = new IdentityHashMap<>();
 
-    public CachingStatsProvider(StatsCalculator statsCalculator, Session session, Map<Symbol, Type> types)
+    public CachingStatsProvider(StatsProvider delegate)
     {
-        this(statsCalculator, Optional.empty(), noLookup(), session, Suppliers.ofInstance(requireNonNull(types, "types is null")));
+        this(delegate, Optional.empty());
     }
 
-    public CachingStatsProvider(StatsCalculator statsCalculator, Optional<Memo> memo, Lookup lookup, Session session, Supplier<Map<Symbol, Type>> types)
+    public CachingStatsProvider(StatsProvider delegate, Optional<Memo> memo)
     {
-        this.statsCalculator = requireNonNull(statsCalculator, "statsCalculator is null");
+        this.delegate = requireNonNull(delegate, "delegate is null");
         this.memo = requireNonNull(memo, "memo is null");
-        this.lookup = requireNonNull(lookup, "lookup is null");
-        this.session = requireNonNull(session, "session is null");
-        this.types = requireNonNull(types, "types is null");
     }
 
     @Override
-    public PlanNodeStatsEstimate getStats(PlanNode node)
+    public PlanNodeStatsEstimate getStats(PlanNode node, StatsProvider wrapper)
     {
         requireNonNull(node, "node is null");
 
         if (node instanceof GroupReference) {
-            return getGroupStats((GroupReference) node);
+            return getGroupStats((GroupReference) node, wrapper);
         }
 
         PlanNodeStatsEstimate stats = cache.get(node);
@@ -70,12 +57,12 @@ public final class CachingStatsProvider
             return stats;
         }
 
-        stats = statsCalculator.calculateStats(node, this, lookup, session, types.get());
+        stats = delegate.getStats(node, wrapper);
         verify(cache.put(node, stats) == null, "Stats already set");
         return stats;
     }
 
-    private PlanNodeStatsEstimate getGroupStats(GroupReference groupReference)
+    private PlanNodeStatsEstimate getGroupStats(GroupReference groupReference, StatsProvider wrapper)
     {
         int group = groupReference.getGroupId();
         Memo memo = this.memo.orElseThrow(() -> new IllegalStateException("CachingStatsProvider without memo cannot handle GroupReferences"));
@@ -85,7 +72,7 @@ public final class CachingStatsProvider
             return stats.get();
         }
 
-        PlanNodeStatsEstimate groupStats = statsCalculator.calculateStats(memo.getNode(group), this, lookup, session, types.get());
+        PlanNodeStatsEstimate groupStats = delegate.getStats(memo.resolve(groupReference), wrapper);
         verify(!memo.getStats(group).isPresent(), "Group stats already set");
         memo.storeStats(group, groupStats);
         return groupStats;

--- a/presto-main/src/main/java/com/facebook/presto/cost/CalculatingStatsProvider.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/CalculatingStatsProvider.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.cost;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.planner.iterative.Lookup;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+import com.google.common.base.Suppliers;
+
+import java.util.Map;
+import java.util.function.Supplier;
+
+import static com.facebook.presto.sql.planner.iterative.Lookup.noLookup;
+import static java.util.Objects.requireNonNull;
+
+public final class CalculatingStatsProvider
+        extends StatsProvider
+{
+    private final StatsCalculator statsCalculator;
+    private final Lookup lookup;
+    private final Session session;
+    private final Supplier<Map<Symbol, Type>> types;
+
+    public CalculatingStatsProvider(StatsCalculator statsCalculator, Session session, Map<Symbol, Type> types)
+    {
+        this(statsCalculator, noLookup(), session, Suppliers.ofInstance(requireNonNull(types, "types is null")));
+    }
+
+    public CalculatingStatsProvider(StatsCalculator statsCalculator, Lookup lookup, Session session, Supplier<Map<Symbol, Type>> types)
+    {
+        this.statsCalculator = requireNonNull(statsCalculator, "statsCalculator is null");
+        this.lookup = requireNonNull(lookup, "lookup is null");
+        this.session = requireNonNull(session, "session is null");
+        this.types = requireNonNull(types, "types is null");
+    }
+
+    @Override
+    public PlanNodeStatsEstimate getStats(PlanNode node, StatsProvider wrapper)
+    {
+        requireNonNull(node, "node is null");
+
+        return statsCalculator.calculateStats(node, wrapper, lookup, session, types.get());
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/cost/StatsProvider.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/StatsProvider.java
@@ -15,7 +15,12 @@ package com.facebook.presto.cost;
 
 import com.facebook.presto.sql.planner.plan.PlanNode;
 
-public interface StatsProvider
+public abstract class StatsProvider
 {
-    PlanNodeStatsEstimate getStats(PlanNode node);
+    public final PlanNodeStatsEstimate getStats(PlanNode node)
+    {
+        return getStats(node, this);
+    }
+
+    public abstract PlanNodeStatsEstimate getStats(PlanNode node, StatsProvider wrapper);
 }

--- a/presto-main/src/main/java/com/facebook/presto/cost/StatsProviderFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/StatsProviderFactory.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.cost;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.planner.iterative.Lookup;
+import com.facebook.presto.sql.planner.iterative.Memo;
+
+import java.util.Map;
+import java.util.function.Supplier;
+
+public interface StatsProviderFactory
+{
+    StatsProvider create(Memo memo, Lookup lookup, Session session, Supplier<Map<Symbol, Type>> types);
+}

--- a/presto-main/src/main/java/com/facebook/presto/server/testing/TestingPrestoServer.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/testing/TestingPrestoServer.java
@@ -17,6 +17,7 @@ import com.facebook.presto.connector.ConnectorId;
 import com.facebook.presto.connector.ConnectorManager;
 import com.facebook.presto.cost.CachingStatsProvider;
 import com.facebook.presto.cost.CalculatingStatsProvider;
+import com.facebook.presto.cost.MemoStatsProvider;
 import com.facebook.presto.cost.StatsCalculator;
 import com.facebook.presto.cost.StatsProviderFactory;
 import com.facebook.presto.eventlistener.EventListenerManager;
@@ -372,9 +373,10 @@ public class TestingPrestoServer
     public StatsProviderFactory getStatsProviderFactory()
     {
         return (memo, lookup, session, types) -> {
-            return new CachingStatsProvider(
-                    new CalculatingStatsProvider(getStatsCalculator(), lookup, session, types),
-                    Optional.of(memo));
+            return new MemoStatsProvider(
+                    new CachingStatsProvider(
+                            new CalculatingStatsProvider(getStatsCalculator(), lookup, session, types)),
+                    memo);
         };
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/server/testing/TestingPrestoServer.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/testing/TestingPrestoServer.java
@@ -15,7 +15,9 @@ package com.facebook.presto.server.testing;
 
 import com.facebook.presto.connector.ConnectorId;
 import com.facebook.presto.connector.ConnectorManager;
+import com.facebook.presto.cost.CachingStatsProvider;
 import com.facebook.presto.cost.StatsCalculator;
+import com.facebook.presto.cost.StatsProviderFactory;
 import com.facebook.presto.eventlistener.EventListenerManager;
 import com.facebook.presto.execution.QueryManager;
 import com.facebook.presto.execution.TaskManager;
@@ -364,6 +366,11 @@ public class TestingPrestoServer
     public StatsCalculator getStatsCalculator()
     {
         return statsCalculator;
+    }
+
+    public StatsProviderFactory getStatsProviderFactory()
+    {
+        return (memo, lookup, session, types) -> new CachingStatsProvider(statsCalculator, Optional.of(memo), lookup, session, types);
     }
 
     public TestingAccessControlManager getAccessControl()

--- a/presto-main/src/main/java/com/facebook/presto/server/testing/TestingPrestoServer.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/testing/TestingPrestoServer.java
@@ -16,6 +16,7 @@ package com.facebook.presto.server.testing;
 import com.facebook.presto.connector.ConnectorId;
 import com.facebook.presto.connector.ConnectorManager;
 import com.facebook.presto.cost.CachingStatsProvider;
+import com.facebook.presto.cost.CalculatingStatsProvider;
 import com.facebook.presto.cost.StatsCalculator;
 import com.facebook.presto.cost.StatsProviderFactory;
 import com.facebook.presto.eventlistener.EventListenerManager;
@@ -370,7 +371,11 @@ public class TestingPrestoServer
 
     public StatsProviderFactory getStatsProviderFactory()
     {
-        return (memo, lookup, session, types) -> new CachingStatsProvider(statsCalculator, Optional.of(memo), lookup, session, types);
+        return (memo, lookup, session, types) -> {
+            return new CachingStatsProvider(
+                    new CalculatingStatsProvider(getStatsCalculator(), lookup, session, types),
+                    Optional.of(memo));
+        };
     }
 
     public TestingAccessControlManager getAccessControl()

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -18,6 +18,7 @@ import com.facebook.presto.cost.CalculatingStatsProvider;
 import com.facebook.presto.cost.CostCalculator;
 import com.facebook.presto.cost.CostCalculator.EstimatedExchanges;
 import com.facebook.presto.cost.CostComparator;
+import com.facebook.presto.cost.MemoStatsProvider;
 import com.facebook.presto.cost.StatsCalculator;
 import com.facebook.presto.cost.StatsProviderFactory;
 import com.facebook.presto.metadata.Metadata;
@@ -119,7 +120,6 @@ import javax.annotation.PreDestroy;
 import javax.inject.Inject;
 
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 
 public class PlanOptimizers
@@ -180,8 +180,10 @@ public class PlanOptimizers
                 new MergeFilters());
 
         StatsProviderFactory statsProviderFactory = (memo, lookup, session, types) -> {
-            return new CachingStatsProvider(
-                    new CalculatingStatsProvider(statsCalculator, lookup, session, types), Optional.of(memo));
+            return new MemoStatsProvider(
+                    new CachingStatsProvider(
+                            new CalculatingStatsProvider(statsCalculator, lookup, session, types)),
+                    memo);
         };
 
         // TODO: Once we've migrated handling all the plan node types, replace uses of PruneUnreferencedOutputs with an IterativeOptimizer containing these rules.

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.sql.planner;
 
 import com.facebook.presto.cost.CachingStatsProvider;
+import com.facebook.presto.cost.CalculatingStatsProvider;
 import com.facebook.presto.cost.CostCalculator;
 import com.facebook.presto.cost.CostCalculator.EstimatedExchanges;
 import com.facebook.presto.cost.CostComparator;
@@ -178,7 +179,10 @@ public class PlanOptimizers
         Set<Rule<?>> predicatePushDownRules = ImmutableSet.of(
                 new MergeFilters());
 
-        StatsProviderFactory statsProviderFactory = (memo, lookup, session, types) -> new CachingStatsProvider(statsCalculator, Optional.of(memo), lookup, session, types);
+        StatsProviderFactory statsProviderFactory = (memo, lookup, session, types) -> {
+            return new CachingStatsProvider(
+                    new CalculatingStatsProvider(statsCalculator, lookup, session, types), Optional.of(memo));
+        };
 
         // TODO: Once we've migrated handling all the plan node types, replace uses of PruneUnreferencedOutputs with an IterativeOptimizer containing these rules.
         Set<Rule<?>> columnPruningRules = ImmutableSet.of(

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/ReorderJoins.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/ReorderJoins.java
@@ -18,13 +18,17 @@ import com.facebook.presto.Session;
 import com.facebook.presto.cost.CostComparator;
 import com.facebook.presto.cost.CostProvider;
 import com.facebook.presto.cost.PlanNodeCostEstimate;
+import com.facebook.presto.cost.PlanNodeStatsEstimate;
+import com.facebook.presto.cost.StatsProvider;
 import com.facebook.presto.matching.Captures;
 import com.facebook.presto.matching.Pattern;
 import com.facebook.presto.sql.analyzer.FeaturesConfig;
 import com.facebook.presto.sql.planner.EqualityInference;
 import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
+import com.facebook.presto.sql.planner.SimplePlanVisitor;
 import com.facebook.presto.sql.planner.Symbol;
 import com.facebook.presto.sql.planner.SymbolsExtractor;
+import com.facebook.presto.sql.planner.iterative.GroupReference;
 import com.facebook.presto.sql.planner.iterative.Rule;
 import com.facebook.presto.sql.planner.plan.FilterNode;
 import com.facebook.presto.sql.planner.plan.JoinNode;
@@ -70,6 +74,7 @@ import static com.facebook.presto.sql.tree.ComparisonExpressionType.EQUAL;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Predicates.in;
+import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.common.collect.Iterables.getOnlyElement;
@@ -371,8 +376,6 @@ public class ReorderJoins
 
         private JoinEnumerationResult setJoinNodeProperties(JoinNode joinNode)
         {
-            // TODO avoid stat (but not cost) recalculation for all considered (distribution,flip) pairs, since resulting relation is the same in all case
-
             List<JoinEnumerationResult> possibleJoinNodes = new ArrayList<>();
             FeaturesConfig.JoinDistributionType joinDistributionType = getJoinDistributionType(session);
             if (joinDistributionType.canRepartition() && !joinNode.isCrossJoin()) {
@@ -418,6 +421,65 @@ public class ReorderJoins
         public PlanNodeCostEstimate getCost()
         {
             return cost;
+        }
+    }
+
+    public static class EquivalentJoinCachingStatsProvider
+            extends StatsProvider
+    {
+        private final StatsProvider delegate;
+        private final Map<Set<Integer>, PlanNodeStatsEstimate> cache = new HashMap<>();
+
+        public EquivalentJoinCachingStatsProvider(StatsProvider delegate)
+        {
+            this.delegate = requireNonNull(delegate, "delegate is null");
+        }
+
+        @Override
+        public PlanNodeStatsEstimate getStats(PlanNode node, StatsProvider wrapper)
+        {
+            if (isReorderJoinsJoinNode(node)) {
+                Set<Integer> groupIds = getGroupIds(node);
+                PlanNodeStatsEstimate stats = cache.get(groupIds);
+                if (stats != null) {
+                    return stats;
+                }
+                stats = delegate.getStats(node, wrapper);
+                verify(cache.put(groupIds, stats) == null, "Stats already set");
+                return stats;
+            }
+
+            return delegate.getStats(node, wrapper);
+        }
+
+        private Set<Integer> getGroupIds(PlanNode planNode)
+        {
+            ImmutableSet.Builder<Integer> groupIds = ImmutableSet.builder();
+            planNode.accept(new GroupIdCollector(), groupIds);
+            return groupIds.build();
+        }
+
+        private boolean isReorderJoinsJoinNode(PlanNode node)
+        {
+            if (node instanceof JoinNode) {
+                JoinNode joinNode = (JoinNode) node;
+                return joinNode.getType() == INNER
+                        && !joinNode.getFilter().isPresent()
+                        && isReorderJoinsJoinNode(joinNode.getLeft())
+                        && isReorderJoinsJoinNode(joinNode.getRight());
+            }
+            return node instanceof GroupReference;
+        }
+
+        private static final class GroupIdCollector
+                extends SimplePlanVisitor<ImmutableSet.Builder<Integer>>
+        {
+            @Override
+            public Void visitGroupReference(GroupReference node, ImmutableSet.Builder<Integer> groupIds)
+            {
+                groupIds.add(node.getGroupId());
+                return null;
+            }
         }
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanPrinter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanPrinter.java
@@ -16,6 +16,7 @@ package com.facebook.presto.sql.planner.planPrinter;
 import com.facebook.presto.Session;
 import com.facebook.presto.cost.CachingCostProvider;
 import com.facebook.presto.cost.CachingStatsProvider;
+import com.facebook.presto.cost.CalculatingStatsProvider;
 import com.facebook.presto.cost.CostCalculator;
 import com.facebook.presto.cost.CostProvider;
 import com.facebook.presto.cost.PlanNodeCostEstimate;
@@ -560,7 +561,7 @@ public class PlanPrinter
         public Visitor(StatsCalculator statsCalculator, CostCalculator costCalculator, Map<Symbol, Type> types, Session session)
         {
             this.types = types;
-            this.statsProvider = new CachingStatsProvider(statsCalculator, session, types);
+            this.statsProvider = new CachingStatsProvider(new CalculatingStatsProvider(statsCalculator, session, types));
             this.costProvider = new CachingCostProvider(costCalculator, statsProvider, session, types);
             this.session = session;
         }

--- a/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
@@ -36,6 +36,7 @@ import com.facebook.presto.cost.CostCalculator;
 import com.facebook.presto.cost.CostCalculatorUsingExchanges;
 import com.facebook.presto.cost.CostCalculatorWithEstimatedExchanges;
 import com.facebook.presto.cost.CostComparator;
+import com.facebook.presto.cost.MemoStatsProvider;
 import com.facebook.presto.cost.ScalarStatsCalculator;
 import com.facebook.presto.cost.SelectingStatsCalculator;
 import com.facebook.presto.cost.SemiJoinStatsCalculator;
@@ -482,9 +483,10 @@ public class LocalQueryRunner
     public StatsProviderFactory getStatsProviderFactory()
     {
         return (memo, lookup, session, types) -> {
-            return new CachingStatsProvider(
-                    new CalculatingStatsProvider(statsCalculator, lookup, session, types),
-                    Optional.of(memo));
+            return new MemoStatsProvider(
+                    new CachingStatsProvider(
+                            new CalculatingStatsProvider(statsCalculator, lookup, session, types)),
+                    memo);
         };
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
@@ -29,6 +29,7 @@ import com.facebook.presto.connector.system.NodeSystemTable;
 import com.facebook.presto.connector.system.SchemaPropertiesSystemTable;
 import com.facebook.presto.connector.system.TablePropertiesSystemTable;
 import com.facebook.presto.connector.system.TransactionsSystemTable;
+import com.facebook.presto.cost.CachingStatsProvider;
 import com.facebook.presto.cost.CoefficientBasedStatsCalculator;
 import com.facebook.presto.cost.CostCalculator;
 import com.facebook.presto.cost.CostCalculatorUsingExchanges;
@@ -38,6 +39,7 @@ import com.facebook.presto.cost.ScalarStatsCalculator;
 import com.facebook.presto.cost.SelectingStatsCalculator;
 import com.facebook.presto.cost.SemiJoinStatsCalculator;
 import com.facebook.presto.cost.StatsCalculator;
+import com.facebook.presto.cost.StatsProviderFactory;
 import com.facebook.presto.execution.CommitTask;
 import com.facebook.presto.execution.CreateTableTask;
 import com.facebook.presto.execution.CreateViewTask;
@@ -473,6 +475,12 @@ public class LocalQueryRunner
     public StatsCalculator getStatsCalculator()
     {
         return statsCalculator;
+    }
+
+    @Override
+    public StatsProviderFactory getStatsProviderFactory()
+    {
+        return (memo, lookup, session, types) -> new CachingStatsProvider(statsCalculator, Optional.of(memo), lookup, session, types);
     }
 
     public CostCalculator getCostCalculator()

--- a/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
@@ -30,6 +30,7 @@ import com.facebook.presto.connector.system.SchemaPropertiesSystemTable;
 import com.facebook.presto.connector.system.TablePropertiesSystemTable;
 import com.facebook.presto.connector.system.TransactionsSystemTable;
 import com.facebook.presto.cost.CachingStatsProvider;
+import com.facebook.presto.cost.CalculatingStatsProvider;
 import com.facebook.presto.cost.CoefficientBasedStatsCalculator;
 import com.facebook.presto.cost.CostCalculator;
 import com.facebook.presto.cost.CostCalculatorUsingExchanges;
@@ -480,7 +481,11 @@ public class LocalQueryRunner
     @Override
     public StatsProviderFactory getStatsProviderFactory()
     {
-        return (memo, lookup, session, types) -> new CachingStatsProvider(statsCalculator, Optional.of(memo), lookup, session, types);
+        return (memo, lookup, session, types) -> {
+            return new CachingStatsProvider(
+                    new CalculatingStatsProvider(statsCalculator, lookup, session, types),
+                    Optional.of(memo));
+        };
     }
 
     public CostCalculator getCostCalculator()

--- a/presto-main/src/main/java/com/facebook/presto/testing/QueryRunner.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/QueryRunner.java
@@ -15,6 +15,7 @@ package com.facebook.presto.testing;
 
 import com.facebook.presto.Session;
 import com.facebook.presto.cost.StatsCalculator;
+import com.facebook.presto.cost.StatsProviderFactory;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.metadata.QualifiedObjectName;
 import com.facebook.presto.spi.Plugin;
@@ -45,6 +46,8 @@ public interface QueryRunner
     NodePartitioningManager getNodePartitioningManager();
 
     StatsCalculator getStatsCalculator();
+
+    StatsProviderFactory getStatsProviderFactory();
 
     TestingAccessControlManager getAccessControl();
 

--- a/presto-main/src/test/java/com/facebook/presto/cost/SettableStatsProvider.java
+++ b/presto-main/src/test/java/com/facebook/presto/cost/SettableStatsProvider.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.cost;
+
+import com.facebook.presto.sql.planner.plan.PlanNode;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.facebook.presto.cost.PlanNodeStatsEstimate.UNKNOWN_STATS;
+import static java.util.Objects.requireNonNull;
+
+final class SettableStatsProvider
+        extends StatsProvider
+{
+    private Map<PlanNode, PlanNodeStatsEstimate> stats = new HashMap<>();
+
+    @Override
+    public PlanNodeStatsEstimate getStats(PlanNode node, StatsProvider wrapper)
+    {
+        return stats.getOrDefault(node, UNKNOWN_STATS);
+    }
+
+    public void put(PlanNode planNode, PlanNodeStatsEstimate planNodeStats)
+    {
+        requireNonNull(planNode, "planNode is null");
+        requireNonNull(planNodeStats, "planNodeStats is null");
+        stats.put(planNode, planNodeStats);
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestCanonicalize.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestCanonicalize.java
@@ -78,7 +78,7 @@ public class TestCanonicalize
                         new UnaliasSymbolReferences(),
                         new IterativeOptimizer(
                                 new StatsRecorder(),
-                                getQueryRunner().getStatsCalculator(),
+                                getQueryRunner().getStatsProviderFactory(),
                                 getQueryRunner().getCostCalculator(),
                                 ImmutableSet.of(new RemoveRedundantIdentityProjections()))));
     }

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/BasePlanTest.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/BasePlanTest.java
@@ -132,7 +132,7 @@ public class BasePlanTest
                 new PruneUnreferencedOutputs(),
                 new IterativeOptimizer(
                         new StatsRecorder(),
-                        queryRunner.getStatsCalculator(),
+                        queryRunner.getStatsProviderFactory(),
                         queryRunner.getCostCalculator(),
                         ImmutableSet.of(new RemoveRedundantIdentityProjections())));
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/PlanAssert.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/PlanAssert.java
@@ -15,6 +15,7 @@ package com.facebook.presto.sql.planner.assertions;
 
 import com.facebook.presto.Session;
 import com.facebook.presto.cost.CachingStatsProvider;
+import com.facebook.presto.cost.CalculatingStatsProvider;
 import com.facebook.presto.cost.CostCalculator;
 import com.facebook.presto.cost.StatsCalculator;
 import com.facebook.presto.cost.StatsProvider;
@@ -40,7 +41,7 @@ public final class PlanAssert
 
     public static void assertPlan(Session session, Metadata metadata, StatsCalculator statsCalculator, Plan actual, Lookup lookup, PlanMatchPattern pattern)
     {
-        StatsProvider statsProvider = new CachingStatsProvider(statsCalculator, session, actual.getTypes());
+        StatsProvider statsProvider = new CachingStatsProvider(new CalculatingStatsProvider(statsCalculator, session, actual.getTypes()));
         CostCalculator costCalculator = (node, stats, lookup1, session1, types) -> UNKNOWN_COST;
         MatchResult matches = actual.getRoot().accept(new PlanMatchingVisitor(session, metadata, statsProvider, lookup), pattern);
         if (!matches.isMatch()) {

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/TestIterativeOptimizer.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/TestIterativeOptimizer.java
@@ -71,7 +71,7 @@ public class TestIterativeOptimizer
     {
         PlanOptimizer optimizer = new IterativeOptimizer(
                 new StatsRecorder(),
-                queryRunner.getStatsCalculator(),
+                queryRunner.getStatsProviderFactory(),
                 queryRunner.getCostCalculator(),
                 ImmutableSet.of(new NonConvergingRule()));
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestJoinEnumerator.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestJoinEnumerator.java
@@ -16,6 +16,7 @@ package com.facebook.presto.sql.planner.iterative.rule;
 
 import com.facebook.presto.cost.CachingCostProvider;
 import com.facebook.presto.cost.CachingStatsProvider;
+import com.facebook.presto.cost.CalculatingStatsProvider;
 import com.facebook.presto.cost.CostComparator;
 import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
 import com.facebook.presto.sql.planner.Symbol;
@@ -94,11 +95,7 @@ public class TestJoinEnumerator
                 ImmutableList.of(a1, b1));
         SymbolAllocator symbolAllocator = new SymbolAllocator();
         CachingStatsProvider statsProvider = new CachingStatsProvider(
-                queryRunner.getStatsCalculator(),
-                Optional.empty(),
-                noLookup(),
-                queryRunner.getDefaultSession(),
-                symbolAllocator::getTypes);
+                new CalculatingStatsProvider(queryRunner.getStatsCalculator(), noLookup(), queryRunner.getDefaultSession(), symbolAllocator::getTypes));
         CachingCostProvider costProvider = new CachingCostProvider(
                 queryRunner.getCostCalculator(),
                 statsProvider,

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/RuleAssert.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/RuleAssert.java
@@ -19,6 +19,7 @@ import com.facebook.presto.cost.CachingStatsProvider;
 import com.facebook.presto.cost.CalculatingStatsProvider;
 import com.facebook.presto.cost.CostCalculator;
 import com.facebook.presto.cost.CostProvider;
+import com.facebook.presto.cost.MemoStatsProvider;
 import com.facebook.presto.cost.PlanNodeStatsEstimate;
 import com.facebook.presto.cost.StatsCalculator;
 import com.facebook.presto.cost.StatsProvider;
@@ -208,7 +209,10 @@ public class RuleAssert
 
     private Rule.Context ruleContext(StatsCalculator statsCalculator, CostCalculator costCalculator, SymbolAllocator symbolAllocator, Memo memo, Lookup lookup, Session session)
     {
-        StatsProvider statsProvider = new CachingStatsProvider(new CalculatingStatsProvider(statsCalculator, lookup, session, symbolAllocator::getTypes), Optional.of(memo));
+        StatsProvider statsProvider = new MemoStatsProvider(
+                new CachingStatsProvider(
+                        new CalculatingStatsProvider(statsCalculator, lookup, session, symbolAllocator::getTypes)),
+                memo);
         CostProvider costProvider = new CachingCostProvider(costCalculator, statsProvider, Optional.of(memo), lookup, session, symbolAllocator::getTypes);
 
         return new Rule.Context()

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/RuleAssert.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/RuleAssert.java
@@ -16,6 +16,7 @@ package com.facebook.presto.sql.planner.iterative.rule.test;
 import com.facebook.presto.Session;
 import com.facebook.presto.cost.CachingCostProvider;
 import com.facebook.presto.cost.CachingStatsProvider;
+import com.facebook.presto.cost.CalculatingStatsProvider;
 import com.facebook.presto.cost.CostCalculator;
 import com.facebook.presto.cost.CostProvider;
 import com.facebook.presto.cost.PlanNodeStatsEstimate;
@@ -207,7 +208,7 @@ public class RuleAssert
 
     private Rule.Context ruleContext(StatsCalculator statsCalculator, CostCalculator costCalculator, SymbolAllocator symbolAllocator, Memo memo, Lookup lookup, Session session)
     {
-        StatsProvider statsProvider = new CachingStatsProvider(statsCalculator, Optional.of(memo), lookup, session, symbolAllocator::getTypes);
+        StatsProvider statsProvider = new CachingStatsProvider(new CalculatingStatsProvider(statsCalculator, lookup, session, symbolAllocator::getTypes), Optional.of(memo));
         CostProvider costProvider = new CachingCostProvider(costCalculator, statsProvider, Optional.of(memo), lookup, session, symbolAllocator::getTypes);
 
         return new Rule.Context()

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestEliminateSorts.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestEliminateSorts.java
@@ -92,7 +92,7 @@ public class TestEliminateSorts
                 new PruneUnreferencedOutputs(),
                 new IterativeOptimizer(
                         new StatsRecorder(),
-                        getQueryRunner().getStatsCalculator(),
+                        getQueryRunner().getStatsProviderFactory(),
                         getQueryRunner().getCostCalculator(),
                         ImmutableSet.of(new RemoveRedundantIdentityProjections())));
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestMergeWindows.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestMergeWindows.java
@@ -556,7 +556,7 @@ public class TestMergeWindows
                 new UnaliasSymbolReferences(),
                 new IterativeOptimizer(
                         new StatsRecorder(),
-                        getQueryRunner().getStatsCalculator(),
+                        getQueryRunner().getStatsProviderFactory(),
                         getQueryRunner().getEstimatedExchangesCostCalculator(),
                         ImmutableSet.<Rule<?>>builder()
                                 .add(new RemoveRedundantIdentityProjections())

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestMixedDistinctAggregationOptimizer.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestMixedDistinctAggregationOptimizer.java
@@ -114,7 +114,7 @@ public class TestMixedDistinctAggregationOptimizer
                 new UnaliasSymbolReferences(),
                 new IterativeOptimizer(
                         new StatsRecorder(),
-                        getQueryRunner().getStatsCalculator(),
+                        getQueryRunner().getStatsProviderFactory(),
                         getQueryRunner().getEstimatedExchangesCostCalculator(),
                         ImmutableSet.of(new RemoveRedundantIdentityProjections())),
                 new OptimizeMixedDistinctAggregations(getQueryRunner().getMetadata()),

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestReorderWindows.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestReorderWindows.java
@@ -299,7 +299,7 @@ public class TestReorderWindows
                 new UnaliasSymbolReferences(),
                 new IterativeOptimizer(
                         new StatsRecorder(),
-                        getQueryRunner().getStatsCalculator(),
+                        getQueryRunner().getStatsProviderFactory(),
                         getQueryRunner().getEstimatedExchangesCostCalculator(),
                         ImmutableSet.of(
                                 new RemoveRedundantIdentityProjections(),

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestSetFlatteningOptimizer.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestSetFlatteningOptimizer.java
@@ -130,7 +130,7 @@ public class TestSetFlatteningOptimizer
                 new PruneUnreferencedOutputs(),
                 new IterativeOptimizer(
                         new StatsRecorder(),
-                        getQueryRunner().getStatsCalculator(),
+                        getQueryRunner().getStatsProviderFactory(),
                         getQueryRunner().getEstimatedExchangesCostCalculator(),
                         ImmutableSet.of(new RemoveRedundantIdentityProjections())),
                 new SetFlatteningOptimizer());

--- a/presto-tests/src/main/java/com/facebook/presto/tests/DistributedQueryRunner.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/DistributedQueryRunner.java
@@ -15,7 +15,9 @@ package com.facebook.presto.tests;
 
 import com.facebook.presto.Session;
 import com.facebook.presto.connector.ConnectorId;
+import com.facebook.presto.cost.CachingStatsProvider;
 import com.facebook.presto.cost.StatsCalculator;
+import com.facebook.presto.cost.StatsProviderFactory;
 import com.facebook.presto.execution.QueryInfo;
 import com.facebook.presto.execution.QueryManager;
 import com.facebook.presto.metadata.AllNodes;
@@ -50,6 +52,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
@@ -251,6 +254,12 @@ public class DistributedQueryRunner
     public StatsCalculator getStatsCalculator()
     {
         return coordinator.getStatsCalculator();
+    }
+
+    @Override
+    public StatsProviderFactory getStatsProviderFactory()
+    {
+        return (memo, lookup, session, types) -> new CachingStatsProvider(getStatsCalculator(), Optional.of(memo), lookup, session, types);
     }
 
     @Override

--- a/presto-tests/src/main/java/com/facebook/presto/tests/DistributedQueryRunner.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/DistributedQueryRunner.java
@@ -15,7 +15,6 @@ package com.facebook.presto.tests;
 
 import com.facebook.presto.Session;
 import com.facebook.presto.connector.ConnectorId;
-import com.facebook.presto.cost.CachingStatsProvider;
 import com.facebook.presto.cost.StatsCalculator;
 import com.facebook.presto.cost.StatsProviderFactory;
 import com.facebook.presto.execution.QueryInfo;
@@ -52,7 +51,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
@@ -259,7 +257,7 @@ public class DistributedQueryRunner
     @Override
     public StatsProviderFactory getStatsProviderFactory()
     {
-        return (memo, lookup, session, types) -> new CachingStatsProvider(getStatsCalculator(), Optional.of(memo), lookup, session, types);
+        return coordinator.getStatsProviderFactory();
     }
 
     @Override

--- a/presto-tests/src/main/java/com/facebook/presto/tests/StandaloneQueryRunner.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/StandaloneQueryRunner.java
@@ -16,6 +16,7 @@ package com.facebook.presto.tests;
 import com.facebook.presto.Session;
 import com.facebook.presto.connector.ConnectorId;
 import com.facebook.presto.cost.StatsCalculator;
+import com.facebook.presto.cost.StatsProviderFactory;
 import com.facebook.presto.metadata.AllNodes;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.metadata.QualifiedObjectName;
@@ -144,6 +145,12 @@ public final class StandaloneQueryRunner
     public StatsCalculator getStatsCalculator()
     {
         return server.getStatsCalculator();
+    }
+
+    @Override
+    public StatsProviderFactory getStatsProviderFactory()
+    {
+        return server.getStatsProviderFactory();
     }
 
     @Override

--- a/presto-tests/src/main/java/com/facebook/presto/tests/statistics/MetricComparator.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/statistics/MetricComparator.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.tests.statistics;
 
 import com.facebook.presto.Session;
+import com.facebook.presto.cost.CalculatingStatsProvider;
 import com.facebook.presto.cost.PlanNodeStatsEstimate;
 import com.facebook.presto.cost.StatsCalculator;
 import com.facebook.presto.spi.type.Type;
@@ -79,7 +80,7 @@ final class MetricComparator
         // We calculate stats one-off, so caching is not necessary
         return statsCalculator.calculateStats(
                 node,
-                source -> calculateStats(source, statsCalculator, session, types),
+                new CalculatingStatsProvider(statsCalculator, session, types),
                 noLookup(),
                 session,
                 types);

--- a/presto-thrift-connector/src/test/java/com/facebook/presto/connector/thrift/integration/ThriftQueryRunner.java
+++ b/presto-thrift-connector/src/test/java/com/facebook/presto/connector/thrift/integration/ThriftQueryRunner.java
@@ -19,6 +19,7 @@ import com.facebook.presto.connector.thrift.location.HostList;
 import com.facebook.presto.connector.thrift.server.ThriftIndexedTpchService;
 import com.facebook.presto.connector.thrift.server.ThriftTpchService;
 import com.facebook.presto.cost.StatsCalculator;
+import com.facebook.presto.cost.StatsProviderFactory;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.metadata.QualifiedObjectName;
 import com.facebook.presto.server.testing.TestingPrestoServer;
@@ -185,6 +186,12 @@ public final class ThriftQueryRunner
         public StatsCalculator getStatsCalculator()
         {
             return source.getStatsCalculator();
+        }
+
+        @Override
+        public StatsProviderFactory getStatsProviderFactory()
+        {
+            return source.getStatsProviderFactory();
         }
 
         @Override


### PR DESCRIPTION
Cache stats for equivalent joins for ReorderJoins

I haven't run a lot of benchmarks, below is the result for join reordering with 6 nodes.
Before:
```
Benchmark                                                  Mode  Cnt   Score   Error  Units
BenchmarkReorderJoinsConnectedGraph.benchmarkReorderJoins  avgt   30  65.014 ± 1.838  ms/op
```
After:
```
Benchmark                                                  Mode  Cnt   Score   Error  Units
BenchmarkReorderJoinsConnectedGraph.benchmarkReorderJoins  avgt   30  37.639 ± 1.340  ms/op
```
