### PR TITLE
Cache stats for equivalent join nodes

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/cost/CachingStatsProvider.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/CachingStatsProvider.java
@@ -15,19 +15,30 @@ package com.facebook.presto.cost;
 
 import com.facebook.presto.Session;
 import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.sql.planner.SimplePlanVisitor;
 import com.facebook.presto.sql.planner.Symbol;
 import com.facebook.presto.sql.planner.iterative.GroupReference;
 import com.facebook.presto.sql.planner.iterative.Lookup;
 import com.facebook.presto.sql.planner.iterative.Memo;
+import com.facebook.presto.sql.planner.plan.JoinNode;
 import com.facebook.presto.sql.planner.plan.PlanNode;
+import com.facebook.presto.sql.tree.Expression;
 import com.google.common.base.Suppliers;
+import com.google.common.collect.ImmutableSet;
 
+import javax.annotation.Nullable;
+
+import java.util.HashMap;
 import java.util.IdentityHashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 import static com.facebook.presto.sql.planner.iterative.Lookup.noLookup;
+import static com.facebook.presto.sql.planner.plan.JoinNode.Type.INNER;
 import static com.google.common.base.Verify.verify;
 import static java.util.Objects.requireNonNull;
 
@@ -41,6 +52,7 @@ public final class CachingStatsProvider
     private final Supplier<Map<Symbol, Type>> types;
 
     private final Map<PlanNode, PlanNodeStatsEstimate> cache = new IdentityHashMap<>();
+    private final EquivalentJoinCache equivalentJoinCache = new EquivalentJoinCache(this::calculateStats);
 
     public CachingStatsProvider(StatsCalculator statsCalculator, Session session, Map<Symbol, Type> types)
     {
@@ -70,9 +82,20 @@ public final class CachingStatsProvider
             return stats;
         }
 
-        stats = statsCalculator.calculateStats(node, this, lookup, session, types.get());
+        stats = equivalentJoinCache.getStats(node);
+        if (stats != null) {
+            verify(cache.put(node, stats) == null, "Stats already set");
+            return stats;
+        }
+
+        stats = calculateStats(node);
         verify(cache.put(node, stats) == null, "Stats already set");
         return stats;
+    }
+
+    private PlanNodeStatsEstimate calculateStats(PlanNode node)
+    {
+        return statsCalculator.calculateStats(node, this, lookup, session, types.get());
     }
 
     private PlanNodeStatsEstimate getGroupStats(GroupReference groupReference)
@@ -85,9 +108,132 @@ public final class CachingStatsProvider
             return stats.get();
         }
 
-        PlanNodeStatsEstimate groupStats = statsCalculator.calculateStats(memo.getNode(group), this, lookup, session, types.get());
+        PlanNodeStatsEstimate groupStats = calculateStats(memo.getNode(group));
         verify(!memo.getStats(group).isPresent(), "Group stats already set");
         memo.storeStats(group, groupStats);
         return groupStats;
+    }
+
+    private static final class EquivalentJoinCache
+    {
+        private final Function<PlanNode, PlanNodeStatsEstimate> statsProvider;
+        private final Map<CacheKey, PlanNodeStatsEstimate> cache = new HashMap<>();
+
+        public EquivalentJoinCache(Function<PlanNode, PlanNodeStatsEstimate> statsProvider)
+        {
+            this.statsProvider = requireNonNull(statsProvider, "statsProvider is null");
+        }
+
+        @Nullable
+        public PlanNodeStatsEstimate getStats(PlanNode node)
+        {
+            if (isInnerJoinNode(node)) {
+                CacheKey cacheKey = getCacheKey(node);
+                PlanNodeStatsEstimate stats = cache.get(cacheKey);
+                if (stats != null) {
+                    return stats;
+                }
+                stats = statsProvider.apply(node);
+                verify(cache.put(cacheKey, stats) == null, "Stats already set");
+                return stats;
+            }
+
+            return null;
+        }
+
+        private CacheKey getCacheKey(PlanNode planNode)
+        {
+            ImmutableSet.Builder<Integer> groupIds = ImmutableSet.builder();
+            planNode.accept(new GroupIdCollector(), groupIds);
+
+            ImmutableSet.Builder<JoinNode.EquiJoinClause> criteria = ImmutableSet.builder();
+            planNode.accept(new CriteriaCollector(), criteria);
+
+            ImmutableSet.Builder<Expression> filters = ImmutableSet.builder();
+            planNode.accept(new FilterCollector(), filters);
+
+            return new CacheKey(groupIds.build(), criteria.build(), filters.build());
+        }
+
+        private boolean isInnerJoinNode(PlanNode node)
+        {
+            if (node instanceof JoinNode) {
+                JoinNode joinNode = (JoinNode) node;
+                return joinNode.getType() == INNER
+                        && (joinNode.getLeft() instanceof GroupReference || isInnerJoinNode(joinNode.getLeft()))
+                        && (joinNode.getRight() instanceof GroupReference || isInnerJoinNode(joinNode.getRight()));
+            }
+            return false;
+        }
+
+        private static final class GroupIdCollector
+                extends SimplePlanVisitor<ImmutableSet.Builder<Integer>>
+        {
+            @Override
+            public Void visitGroupReference(GroupReference node, ImmutableSet.Builder<Integer> groupIds)
+            {
+                groupIds.add(node.getGroupId());
+                return null;
+            }
+        }
+
+        private static final class CriteriaCollector
+                extends SimplePlanVisitor<ImmutableSet.Builder<JoinNode.EquiJoinClause>>
+        {
+            @Override
+            public Void visitJoin(JoinNode node, ImmutableSet.Builder<JoinNode.EquiJoinClause> criteria)
+            {
+                super.visitPlan(node, criteria);
+                criteria.addAll(node.getCriteria());
+                return null;
+            }
+        }
+
+        private static final class FilterCollector
+                extends SimplePlanVisitor<ImmutableSet.Builder<Expression>>
+        {
+            @Override
+            public Void visitJoin(JoinNode node, ImmutableSet.Builder<Expression> filters)
+            {
+                super.visitPlan(node, filters);
+                node.getFilter().ifPresent(filters::add);
+                return null;
+            }
+        }
+
+        private static final class CacheKey
+        {
+            private final Set<Integer> groupIds;
+            private final Set<JoinNode.EquiJoinClause> criteria;
+            private final Set<Expression> filter;
+
+            public CacheKey(Set<Integer> groupIds, Set<JoinNode.EquiJoinClause> criteria, Set<Expression> filter)
+            {
+                this.groupIds = ImmutableSet.copyOf(requireNonNull(groupIds, "groupIds is null"));
+                this.criteria = ImmutableSet.copyOf(requireNonNull(criteria, "criteria is null"));
+                this.filter = ImmutableSet.copyOf(requireNonNull(filter, "criteria is null"));
+            }
+
+            @Override
+            public boolean equals(Object o)
+            {
+                if (this == o) {
+                    return true;
+                }
+                if (o == null || getClass() != o.getClass()) {
+                    return false;
+                }
+                CacheKey cacheKey = (CacheKey) o;
+                return Objects.equals(groupIds, cacheKey.groupIds) &&
+                        Objects.equals(criteria, cacheKey.criteria) &&
+                        Objects.equals(filter, cacheKey.filter);
+            }
+
+            @Override
+            public int hashCode()
+            {
+                return Objects.hash(groupIds, criteria, filter);
+            }
+        }
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/ReorderJoins.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/ReorderJoins.java
@@ -371,8 +371,6 @@ public class ReorderJoins
 
         private JoinEnumerationResult setJoinNodeProperties(JoinNode joinNode)
         {
-            // TODO avoid stat (but not cost) recalculation for all considered (distribution,flip) pairs, since resulting relation is the same in all case
-
             List<JoinEnumerationResult> possibleJoinNodes = new ArrayList<>();
             FeaturesConfig.JoinDistributionType joinDistributionType = getJoinDistributionType(session);
             if (joinDistributionType.canRepartition() && !joinNode.isCrossJoin()) {


### PR DESCRIPTION
Cache stats for equivalent join nodes

Before:
```
Benchmark                                                  Mode  Cnt   Score   Error  Units
BenchmarkReorderJoinsConnectedGraph.benchmarkReorderJoins  avgt   30  65.014 ± 1.838  ms/op
BenchmarkReorderJoinsConnectedGraph.benchmarkReorderJoins  avgt   30  575.709 ± 15.893  ms/op
```

After:

```
Benchmark                                                  Mode  Cnt   Score   Error  Units
BenchmarkReorderJoinsConnectedGraph.benchmarkReorderJoins  avgt   30  53.536 ± 1.490  ms/op
BenchmarkReorderJoinsConnectedGraph.benchmarkReorderJoins  avgt   30  446.159 ± 15.670  ms/op
```