### PR TITLE
Reorder joins

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/MultiJoinNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/MultiJoinNode.java
@@ -23,10 +23,9 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 
 import java.util.ArrayList;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Objects;
-import java.util.Set;
 
 import static com.facebook.presto.sql.ExpressionUtils.and;
 import static com.facebook.presto.sql.ExpressionUtils.extractConjuncts;
@@ -43,11 +42,12 @@ import static java.util.Objects.requireNonNull;
  */
 class MultiJoinNode
 {
-    private final Set<PlanNode> sources;
+    // Use a linked hash set to ensure optimizer is deterministic
+    private final LinkedHashSet<PlanNode> sources;
     private final Expression filter;
     private final List<Symbol> outputSymbols;
 
-    public MultiJoinNode(Set<PlanNode> sources, Expression filter, List<Symbol> outputSymbols)
+    public MultiJoinNode(LinkedHashSet<PlanNode> sources, Expression filter, List<Symbol> outputSymbols)
     {
         requireNonNull(sources, "sources is null");
         checkArgument(sources.size() > 1);
@@ -67,7 +67,7 @@ class MultiJoinNode
         return filter;
     }
 
-    public Set<PlanNode> getSources()
+    public LinkedHashSet<PlanNode> getSources()
     {
         return sources;
     }
@@ -103,7 +103,7 @@ class MultiJoinNode
 
     private static class JoinNodeFlattener
     {
-        private final Set<PlanNode> sources = new HashSet<>();
+        private final LinkedHashSet<PlanNode> sources = new LinkedHashSet<>();
         private final List<Expression> filters = new ArrayList<>();
         private final List<Symbol> outputSymbols;
         private final Lookup lookup;

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestJoinEnumerator.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestJoinEnumerator.java
@@ -34,6 +34,7 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
+import java.util.LinkedHashSet;
 import java.util.Optional;
 import java.util.Set;
 
@@ -93,7 +94,7 @@ public class TestJoinEnumerator
         Symbol a1 = planBuilder.symbol("A1", BIGINT);
         Symbol b1 = planBuilder.symbol("B1", BIGINT);
         MultiJoinNode multiJoinNode = new MultiJoinNode(
-                ImmutableSet.of(planBuilder.values(a1), planBuilder.values(b1)),
+                new LinkedHashSet<>(ImmutableList.of(planBuilder.values(a1), planBuilder.values(b1))),
                 TRUE_LITERAL,
                 ImmutableList.of(a1, b1));
         SymbolAllocator symbolAllocator = new SymbolAllocator();

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestJoinNodeFlattener.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestJoinNodeFlattener.java
@@ -25,11 +25,11 @@ import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.LongLiteral;
 import com.facebook.presto.testing.LocalQueryRunner;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
+import java.util.LinkedHashSet;
 import java.util.Optional;
 
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
@@ -103,7 +103,7 @@ public class TestJoinNodeFlattener
                 ImmutableList.of(a1, b1, c1),
                 Optional.empty());
 
-        MultiJoinNode expected = new MultiJoinNode(ImmutableSet.of(leftJoin, valuesC), new ComparisonExpression(EQUAL, a1.toSymbolReference(), c1.toSymbolReference()), ImmutableList.of(a1, b1, c1));
+        MultiJoinNode expected = new MultiJoinNode(new LinkedHashSet<>(ImmutableList.of(leftJoin, valuesC)), new ComparisonExpression(EQUAL, a1.toSymbolReference(), c1.toSymbolReference()), ImmutableList.of(a1, b1, c1));
         assertEquals(toMultiJoinNode(joinNode, noLookup(), DEFAULT_JOIN_LIMIT), expected);
     }
 
@@ -138,7 +138,7 @@ public class TestJoinNodeFlattener
                 ImmutableList.of(a1, b1),
                 Optional.empty());
         MultiJoinNode expected = new MultiJoinNode(
-                ImmutableSet.of(valuesA, valuesB, valuesC),
+                new LinkedHashSet<>(ImmutableList.of(valuesA, valuesB, valuesC)),
                 and(new ComparisonExpression(EQUAL, b1.toSymbolReference(), c1.toSymbolReference()), new ComparisonExpression(EQUAL, a1.toSymbolReference(), b1.toSymbolReference())),
                 ImmutableList.of(a1, b1));
         assertEquals(toMultiJoinNode(joinNode, noLookup(), DEFAULT_JOIN_LIMIT), expected);
@@ -183,7 +183,7 @@ public class TestJoinNodeFlattener
                 ImmutableList.of(a1, b1, b2, c1, c2),
                 Optional.of(abcFilter));
         MultiJoinNode expected = new MultiJoinNode(
-                ImmutableSet.of(valuesA, valuesB, valuesC),
+                new LinkedHashSet<>(ImmutableList.of(valuesA, valuesB, valuesC)),
                 and(new ComparisonExpression(EQUAL, b1.toSymbolReference(), c1.toSymbolReference()), new ComparisonExpression(EQUAL, a1.toSymbolReference(), b1.toSymbolReference()), bcFilter, abcFilter),
                 ImmutableList.of(a1, b1, b2, c1, c2));
         assertEquals(toMultiJoinNode(joinNode, noLookup(), DEFAULT_JOIN_LIMIT), expected);
@@ -245,7 +245,7 @@ public class TestJoinNodeFlattener
                         e2),
                 Optional.empty());
         MultiJoinNode expected = new MultiJoinNode(
-                ImmutableSet.of(valuesA, valuesB, valuesC, valuesD, valuesE),
+                new LinkedHashSet<>(ImmutableList.of(valuesA, valuesB, valuesC, valuesD, valuesE)),
                 and(
                         new ComparisonExpression(EQUAL, a1.toSymbolReference(), b1.toSymbolReference()),
                         new ComparisonExpression(EQUAL, a1.toSymbolReference(), c1.toSymbolReference()),
@@ -314,7 +314,7 @@ public class TestJoinNodeFlattener
                         e2),
                 Optional.empty());
         MultiJoinNode expected = new MultiJoinNode(
-                ImmutableSet.of(join1, join2, valuesC),
+                new LinkedHashSet<>(ImmutableList.of(join1, join2, valuesC)),
                 and(
                         new ComparisonExpression(EQUAL, a1.toSymbolReference(), c1.toSymbolReference()),
                         new ComparisonExpression(EQUAL, b1.toSymbolReference(), e1.toSymbolReference())),


### PR DESCRIPTION
Sorry... I still didn't rebase, but I have to go for the evening (if it's a problem I can rebase tomorrow morning).  The only new commit here is the last one to use a LinkedHashSet.  The testKeepsOutputSymbols failure was non-deterministic, but I'm hoping this commit fixes it.  I just ran it a bunch of times in a row with no failures.