### PR TITLE
Fix semantics of SHOW ROLES and information_schema.roles

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/security/LegacyAccessControl.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/security/LegacyAccessControl.java
@@ -204,12 +204,6 @@ public class LegacyAccessControl
     }
 
     @Override
-    public Set<String> filterRoles(ConnectorTransactionHandle transactionHandle, ConnectorIdentity identity, String catalogName, Set<String> roles)
-    {
-        return roles;
-    }
-
-    @Override
     public void checkCanShowCurrentRoles(ConnectorTransactionHandle transactionHandle, ConnectorIdentity identity, String catalogName)
     {
     }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/security/PartitionsAwareAccessControl.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/security/PartitionsAwareAccessControl.java
@@ -219,12 +219,6 @@ public class PartitionsAwareAccessControl
     }
 
     @Override
-    public Set<String> filterRoles(ConnectorTransactionHandle transactionHandle, ConnectorIdentity identity, String catalogName, Set<String> roles)
-    {
-        return delegate.filterRoles(transactionHandle, identity, catalogName, roles);
-    }
-
-    @Override
     public void checkCanShowCurrentRoles(ConnectorTransactionHandle transactionHandle, ConnectorIdentity identity, String catalogName)
     {
         delegate.checkCanShowCurrentRoles(transactionHandle, identity, catalogName);

--- a/presto-hive/src/main/java/com/facebook/presto/hive/security/SqlStandardAccessControl.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/security/SqlStandardAccessControl.java
@@ -343,12 +343,6 @@ public class SqlStandardAccessControl
     }
 
     @Override
-    public Set<String> filterRoles(ConnectorTransactionHandle transactionHandle, ConnectorIdentity identity, String catalogName, Set<String> roles)
-    {
-        return roles;
-    }
-
-    @Override
     public void checkCanShowCurrentRoles(ConnectorTransactionHandle transactionHandle, ConnectorIdentity identity, String catalogName)
     {
     }

--- a/presto-main/src/main/java/com/facebook/presto/connector/informationSchema/InformationSchemaPageSourceProvider.java
+++ b/presto-main/src/main/java/com/facebook/presto/connector/informationSchema/InformationSchemaPageSourceProvider.java
@@ -32,6 +32,7 @@ import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.connector.ConnectorPageSourceProvider;
 import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
+import com.facebook.presto.spi.security.AccessDeniedException;
 import com.facebook.presto.spi.security.GrantInfo;
 import com.facebook.presto.spi.security.PrestoPrincipal;
 import com.facebook.presto.spi.security.RoleGrant;
@@ -52,7 +53,6 @@ import static com.facebook.presto.connector.informationSchema.InformationSchemaM
 import static com.facebook.presto.connector.informationSchema.InformationSchemaMetadata.TABLE_TABLE_PRIVILEGES;
 import static com.facebook.presto.connector.informationSchema.InformationSchemaMetadata.TABLE_VIEWS;
 import static com.facebook.presto.connector.informationSchema.InformationSchemaMetadata.informationSchemaTableColumns;
-import static com.facebook.presto.metadata.MetadataListing.listRoles;
 import static com.facebook.presto.metadata.MetadataListing.listSchemas;
 import static com.facebook.presto.metadata.MetadataListing.listTableColumns;
 import static com.facebook.presto.metadata.MetadataListing.listTablePrivileges;
@@ -241,7 +241,15 @@ public class InformationSchemaPageSourceProvider
     private InternalTable buildRoles(Session session, String catalog)
     {
         InternalTable.Builder table = InternalTable.builder(informationSchemaTableColumns(TABLE_ROLES));
-        for (String role : listRoles(session, metadata, accessControl, catalog)) {
+
+        try {
+            accessControl.checkCanShowRoles(session.getRequiredTransactionId(), session.getIdentity(), catalog);
+        }
+        catch (AccessDeniedException exception) {
+            return table.build();
+        }
+
+        for (String role : metadata.listRoles(session, catalog)) {
             table.add(role);
         }
         return table.build();

--- a/presto-main/src/main/java/com/facebook/presto/metadata/MetadataListing.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/MetadataListing.java
@@ -106,10 +106,4 @@ public final class MetadataListing
         }
         return result.build();
     }
-
-    public static Set<String> listRoles(Session session, Metadata metadata, AccessControl accessControl, String catalogName)
-    {
-        Set<String> roles = ImmutableSet.copyOf(metadata.listRoles(session, catalogName));
-        return accessControl.filterRoles(session.getRequiredTransactionId(), session.getIdentity(), catalogName, roles);
-    }
 }

--- a/presto-main/src/main/java/com/facebook/presto/security/AccessControl.java
+++ b/presto-main/src/main/java/com/facebook/presto/security/AccessControl.java
@@ -251,11 +251,6 @@ public interface AccessControl
     void checkCanShowRoles(TransactionId transactionId, Identity identity, String catalogName);
 
     /**
-     * Filter the list of roles to those visible to the identity in the given catalog.
-     */
-    Set<String> filterRoles(TransactionId transactionId, Identity identity, String catalogName, Set<String> roles);
-
-    /**
      * Check if identity is allowed to show current roles on the specified catalog.
      * @throws com.facebook.presto.spi.security.AccessDeniedException if not allowed
      */

--- a/presto-main/src/main/java/com/facebook/presto/security/AccessControlManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/security/AccessControlManager.java
@@ -636,23 +636,6 @@ public class AccessControlManager
     }
 
     @Override
-    public Set<String> filterRoles(TransactionId transactionId, Identity identity, String catalogName, Set<String> roles)
-    {
-        requireNonNull(identity, "identity is null");
-        requireNonNull(roles, "roles is null");
-
-        if (filterCatalogs(identity, ImmutableSet.of(catalogName)).isEmpty()) {
-            return ImmutableSet.of();
-        }
-
-        CatalogAccessControlEntry entry = getConnectorAccessControl(transactionId, catalogName);
-        if (entry != null) {
-            return entry.getAccessControl().filterRoles(entry.getTransactionHandle(transactionId), identity.toConnectorIdentity(catalogName), catalogName, roles);
-        }
-        return roles;
-    }
-
-    @Override
     public void checkCanShowCurrentRoles(TransactionId transactionId, Identity identity, String catalogName)
     {
         requireNonNull(identity, "identity is null");

--- a/presto-main/src/main/java/com/facebook/presto/security/AllowAllAccessControl.java
+++ b/presto-main/src/main/java/com/facebook/presto/security/AllowAllAccessControl.java
@@ -192,12 +192,6 @@ public class AllowAllAccessControl
     }
 
     @Override
-    public Set<String> filterRoles(TransactionId transactionId, Identity identity, String catalogName, Set<String> roles)
-    {
-        return roles;
-    }
-
-    @Override
     public void checkCanShowCurrentRoles(TransactionId transactionId, Identity identity, String catalogName)
     {
     }

--- a/presto-main/src/main/java/com/facebook/presto/security/DenyAllAccessControl.java
+++ b/presto-main/src/main/java/com/facebook/presto/security/DenyAllAccessControl.java
@@ -254,12 +254,6 @@ public class DenyAllAccessControl
     }
 
     @Override
-    public Set<String> filterRoles(TransactionId transactionId, Identity identity, String catalogName, Set<String> roles)
-    {
-        return ImmutableSet.of();
-    }
-
-    @Override
     public void checkCanShowCurrentRoles(TransactionId transactionId, Identity identity, String catalogName)
     {
         denyShowCurrentRoles(catalogName);

--- a/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorAccessControl.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorAccessControl.java
@@ -314,14 +314,6 @@ public interface ConnectorAccessControl
     }
 
     /**
-     * Filter the list of roles to those visible to the identity.
-     */
-    default Set<String> filterRoles(ConnectorTransactionHandle transactionHandle, ConnectorIdentity identity, String catalogName, Set<String> roles)
-    {
-        return Collections.emptySet();
-    }
-
-    /**
      * Check if identity is allowed to show current roles on the specified catalog.
      *
      * @throws com.facebook.presto.spi.security.AccessDeniedException if not allowed


### PR DESCRIPTION
SHOW ROLES should list all roles in catalog (if user is allowed
to list them).
information_schema.roles should list all roles in catalog or
return empty table if user is not allowed to list catalog roles.

This might need to be squashed with Christina commit:
"Add access control checks for SHOW ROLES"